### PR TITLE
Fix: Cannot assign to read only property error

### DIFF
--- a/lib/ssr-caching.js
+++ b/lib/ssr-caching.js
@@ -231,7 +231,8 @@ ReactCompositeComponent.mountComponentCache = function mountComponentCache(trans
   let cacheType;
   let opts;
 
-  const currentElement = this._currentElement;
+  const currentElement = Object.assign({}, this._currentElement);
+  this._currentElement = currentElement;
   const saveProps = currentElement.props;
   const name = this._name;
   const startTime = config.profiling && process.hrtime();


### PR DESCRIPTION
This fixes the error caused by react components being readonly. Perhaps there's a more efficient way but this naive solution works great.